### PR TITLE
Improve generic types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,33 +1,41 @@
 /**
- * @typedef {import('unist').Node} Node
+ * @typedef {import('unist').Data} Data
+ */
+/**
+ * @template {object} [TData=Data]
+ * @typedef {import('unist').Node<TData>} Node<TData>
  * @typedef {import('unist').Parent} Parent
  */
 
 /**
  * Function called with a node to produce a new node.
  *
+ * @template {Node<object>} [OutputNode = Node]
+ * @template {Node<object>} [InputNode = OutputNode]
  * @callback MapFunction
- * @param {Node} node Current node being processed
+ * @param {InputNode} node Current node being processed
  * @param {number} [index] Index of `node`, or `null`
- * @param {Parent} [parent] Parent of `node`, or `null`
- * @returns {Node} Node to be used in the new tree. Its children are not used: if the original node has children, those are mapped.
+ * @param {Parent<InputNode>} [parent] Parent of `node`, or `null`
+ * @returns {OutputNode} Node to be used in the new tree. Its children are not used: if the original node has children, those are mapped.
  */
 
 /**
  * Unist utility to create a new tree by mapping all nodes with the given function.
  *
- * @param {Node} tree Tree to map
- * @param {MapFunction} iteratee Function that returns a new node
- * @returns {Node} New mapped tree.
+ * @template {Node<object>} [OutputNode = Node]
+ * @template {Node<object>} [InputNode = OutputNode]
+ * @param {InputNode} tree Tree to map
+ * @param {MapFunction<OutputNode, InputNode>} iteratee Function that returns a new node
+ * @returns {OutputNode} New mapped tree.
  */
 export function map(tree, iteratee) {
   return preorder(tree, null, null)
 
   /**
-   * @param {Node} node
+   * @param {InputNode} node
    * @param {number} [index]
-   * @param {Parent} [parent]
-   * @returns {Node}
+   * @param {Parent<InputNode>} [parent]
+   * @returns {OutputNode}
    */
   function preorder(node, index, parent) {
     var newNode = Object.assign({}, iteratee(node, index, parent))

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
  * @typedef {import('unist').Data} Data
  */
 /**
- * @template {object} [TData=Data]
- * @typedef {import('unist').Node<TData>} Node<TData>
+ * @template {object} [DateLike=Data]
+ * @typedef {import('unist').Node<DateLike>} Node<DateLike>
  * @typedef {import('unist').Parent} Parent
  */
 

--- a/test.js
+++ b/test.js
@@ -30,8 +30,9 @@ test('unist-util-map', function (t) {
   t.end()
 
   /**
-   * @param {Node} node
-   * @returns {Node}
+   * @template {Node} TNode
+   * @param {TNode} node
+   * @returns {TNode}
    */
   function changeLeaf(node) {
     return node.type === 'leaf'
@@ -40,8 +41,9 @@ test('unist-util-map', function (t) {
   }
 
   /**
-   * @param {Node} node
-   * @returns {Node?}
+   * @template {Node} TNode
+   * @param {TNode} node
+   * @returns {TNode?}
    */
   function nullLeaf(node) {
     return node.type === 'leaf' ? null : node

--- a/test.js
+++ b/test.js
@@ -30,9 +30,9 @@ test('unist-util-map', function (t) {
   t.end()
 
   /**
-   * @template {Node} TNode
-   * @param {TNode} node
-   * @returns {TNode}
+   * @template {Node} NodeLike
+   * @param {NodeLike} node
+   * @returns {NodeLike}
    */
   function changeLeaf(node) {
     return node.type === 'leaf'

--- a/test.js
+++ b/test.js
@@ -41,9 +41,9 @@ test('unist-util-map', function (t) {
   }
 
   /**
-   * @template {Node} TNode
-   * @param {TNode} node
-   * @returns {TNode?}
+   * @template {Node} NodeLike
+   * @param {NodeLike} node
+   * @returns {NodeLike?}
    */
   function nullLeaf(node) {
     return node.type === 'leaf' ? null : node


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR improves the JSDoc types that come with `unist-util-map`.

The existing type of `map` is not generic. This is fine if you just want to map `Node`s to `Node`s, but painful if you want to do typesafe mapping of (e.g.) `hast`-specific node types in your TypeScript code. I came across this scenario while I was working on addressing some bugs in the `rehype-twemojify` plugin.

This PR updates the type of `map` to the following effective type:

```ts
function map<OutputNode extends Node<any> = Node<Data>, InputNode extends Node<any> = OutputNode>(tree: InputNode, iteratee: MapFunction<OutputNode, InputNode>): OutputNode
```

<!--do not edit: pr-->
