### PR TITLE
Fix to add `MapFunction` type back

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 /**
  * @typedef {import('unist').Node} Node
- * @typedef {import('unist').Parent} Parent
  */
 
 /**
- * @template {Node} [T = Node]
- * @typedef {import('./complex-types.js').MapFunction<T>} MapFunction<T>
+ * @template {Node} [Tree=Node]
+ * @typedef {import('./complex-types.js').MapFunction<Tree>} MapFunction
+ *   Function called with a node, its index, and its parent to produce a new
+ *   node.
  */
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 /**
  * @typedef {import('unist').Node} Node
+ * @typedef {import('unist').Parent} Parent
+ */
+
+/**
+ * @template {Node} [T = Node]
+ * @typedef {import('./complex-types.js').MapFunction<T>} MapFunction<T>
  */
 
 /**
@@ -9,7 +15,7 @@
  *   Type of input tree.
  * @param {Tree} tree
  *   Tree to map.
- * @param {import('./complex-types').MapFunction<Tree>} mapFunction
+ * @param {MapFunction<Tree>} mapFunction
  *   Function called with a node, its index, and its parent to produce a new
  *   node.
  * @returns {Tree}

--- a/readme.md
+++ b/readme.md
@@ -133,8 +133,7 @@ if the original node has children, those are mapped instead.
 ## Types
 
 This package is fully typed with [TypeScript][].
-It exports a type `MapFunction<Tree extends Node = Node>` from
-`unist-util-map/complex-types.d.ts` to properly type `MapFunction`s.
+It exports a type `MapFunction<Tree extends Node = Node>` to properly type `MapFunction`s.
 
 ## Compatibility
 

--- a/test.js
+++ b/test.js
@@ -46,10 +46,13 @@ test('unist-util-map', function (t) {
     'should work when passing an empty object'
   )
 
+  /** @type {Root} */
+  const tree = u('root', [u('node', [u('leaf', '1')]), u('leaf', '2')])
+
   t.deepEqual(
-    map(u('root', [u('node', [u('leaf', '1')]), u('leaf', '2')]), asIs),
-    u('root', [u('node', [u('leaf', '1')]), u('leaf', '2')]),
-    'should keep node as-is'
+    map(tree, asIs),
+    tree,
+    'should support an explicitly typed `MapFunction`'
   )
 
   t.end()
@@ -77,7 +80,7 @@ test('unist-util-map', function (t) {
   }
 
   /**
-   * @type {import('./index.js').MapFunction<AnyNode>}
+   * @type {import('./index.js').MapFunction<Root>}
    */
   function asIs(node) {
     return node

--- a/test.js
+++ b/test.js
@@ -46,6 +46,12 @@ test('unist-util-map', function (t) {
     'should work when passing an empty object'
   )
 
+  t.deepEqual(
+    map(u('root', [u('node', [u('leaf', '1')]), u('leaf', '2')]), asIs),
+    u('root', [u('node', [u('leaf', '1')]), u('leaf', '2')]),
+    'should keep node as-is'
+  )
+
   t.end()
 
   /**
@@ -68,5 +74,12 @@ test('unist-util-map', function (t) {
 
   function addValue() {
     return {value: 'test'}
+  }
+
+  /**
+   * @type {import('./index.js').MapFunction<AnyNode>}
+   */
+  function asIs(node) {
+    return node
   }
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

close #6

<!--do not edit: pr-->
