### PR TITLE
Add `replaceChildren` flag

### DIFF
--- a/lib/complex-types.d.ts
+++ b/lib/complex-types.d.ts
@@ -19,5 +19,6 @@ export type InclusiveDescendant<
 export type MapFunction<Tree extends Node = Node> = (
   node: InclusiveDescendant<Tree>,
   index: number | undefined,
-  parent: InclusiveDescendant<Tree> | undefined
+  parent: InclusiveDescendant<Tree> | undefined,
+  replaceChildren?: boolean
 ) => InclusiveDescendant<Tree>

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,24 +20,28 @@
  * @param {MapFunction<Kind>} mapFunction
  *   Function called with a node, its index, and its parent to produce a new
  *   node.
+ * @param {boolean} [replaceChildren=false]
+ *   Whether to replace the children of nodes with the children of the new node.
  * @returns {Kind}
  *   New mapped tree.
  */
-export function map(tree, mapFunction) {
+export function map(tree, mapFunction, replaceChildren = false) {
   // @ts-expect-error Looks like a children.
-  return preorder(tree, null, null)
+  return preorder(tree, null, null, replaceChildren)
 
   /** @type {import('./complex-types.js').MapFunction<Kind>} */
-  function preorder(node, index, parent) {
+  function preorder(node, index, parent, replaceChildren) {
     const newNode = Object.assign({}, mapFunction(node, index, parent))
 
-    if ('children' in node) {
+    let targetNode = replaceChildren ? newNode : node
+
+    if ('children' in targetNode) {
       // @ts-expect-error Looks like a parent.
-      newNode.children = node.children.map(function (
+      newNode.children = targetNode.children.map(function (
         /** @type {import('./complex-types.js').InclusiveDescendant<Kind>} */ child,
         /** @type {number} */ index
       ) {
-        return preorder(child, index, node)
+        return preorder(child, index, targetNode, replaceChildren)
       })
     }
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ function.
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
-    *   [`map(tree, mapFunction)`](#maptree-mapfunction)
+    *   [`map(tree, mapFunction, replaceChildren)`](#maptree-mapfunction)
 *   [Types](#types)
 *   [Compatibility](#compatibility)
 *   [Related](#related)
@@ -110,7 +110,7 @@ Yields:
 This package exports the identifier [`map`][api-map].
 There is no default export.
 
-### `map(tree, mapFunction)`
+### `map(tree, mapFunction, replaceChildren)`
 
 Create a new tree by mapping all nodes with the given function.
 
@@ -121,6 +121,8 @@ Create a new tree by mapping all nodes with the given function.
 *   `mapFunction` ([`MapFunction`][api-mapfunction])
     — function called with a node, its index, and its parent to produce a new
     node
+*   `replaceChildren` (`[boolean=false]`)
+    — whether to replace the children of nodes with the children of the new node.
 
 ###### Returns
 

--- a/test.js
+++ b/test.js
@@ -38,6 +38,12 @@ test('map', function () {
     map(rootB, changeLeaf),
     u('root', [u('node', [u('leaf', 'CHANGED')]), u('leaf', 'CHANGED')]),
     'should map the specified node'
+    )
+
+  assert.deepEqual(
+    map(rootB, changeChildrenLeaf, true),
+    u('root', [u('node', [u('leaf', 'CREATED'), u('leaf', 'CREATED'), ]), u('leaf', '2')]),
+    'should replace the children of nodes with the children of the new node'
   )
 
   /** @type {Root} */
@@ -74,6 +80,16 @@ test('map', function () {
 function changeLeaf(node) {
   return node.type === 'leaf'
     ? Object.assign({}, node, {value: 'CHANGED'})
+    : node
+}
+
+/**
+ * @param {AnyNode} node
+ * @returns {AnyNode}
+ */
+function changeChildrenLeaf(node) {
+  return node.type === 'node'
+    ? Object.assign({}, node, {children: [u('leaf', 'CREATED'), u('leaf', 'CREATED')]})
     : node
 }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [v] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [v] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [v] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [v] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [v] If applicable, I’ve added docs and tests

### Description of changes

`replaceChildren` is whether to replace the children of nodes with the children of the new node.

<!--do not edit: pr-->


related: #8
